### PR TITLE
Fix node_modules overlaid problem

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     ports:
       - "4200:4200"
     volumes:
-      - ./angular-client:/app
+      - ./angular-client/src:/app/src
 
   server:
     build: express-server


### PR DESCRIPTION
Fix problem where the Dockerfile volume mount caused the node_modules folder in the container (built from `npm install`) to be overlaid.

Since we really only want the client to rebuild whenever the front end source changes, the volume mount should only be for the src folder.